### PR TITLE
allow Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "require": {
         "php": ">=8.0.2",
         "ext-json": "*",
-        "symfony/config": "^5.4 || ^6.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0",
-        "symfony/http-kernel": "^5.4 || ^6.0",
-        "symfony/serializer": "^5.4 || ^6.0",
+        "symfony/config": "^5.4 || ^6.0 || 7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || 7.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || 7.0",
+        "symfony/serializer": "^5.4 || ^6.0 || 7.0",
         "easycorp/easyadmin-bundle": "^3.4 || ^v4.0"
     },
     "autoload": {


### PR DESCRIPTION
Since this works with 6.4, it should work with 7.  This will at least allow it to install.